### PR TITLE
Add MEOrderBook unit tests + portability shims

### DIFF
--- a/Chapter12/common/lf_queue.h
+++ b/Chapter12/common/lf_queue.h
@@ -29,7 +29,7 @@ namespace Common {
 
     auto updateReadIndex() noexcept {
       next_read_index_ = (next_read_index_ + 1) % store_.size(); // wrap around at the end of container size.
-      ASSERT(num_elements_ != 0, "Read an invalid element in:" + std::to_string(pthread_self()));
+      ASSERT(num_elements_ != 0, "Read an invalid element in:" + std::to_string((uintptr_t) pthread_self()));
       num_elements_--;
     }
 

--- a/Chapter12/common/perf_utils.h
+++ b/Chapter12/common/perf_utils.h
@@ -1,11 +1,22 @@
 #pragma once
 
+#include <cstdint>
+
 namespace Common {
   /// Read from the TSC register and return a uint64_t value to represent elapsed CPU clock cycles.
-  inline auto rdtsc() noexcept {
+  inline auto rdtsc() noexcept -> uint64_t {
+#if defined(__x86_64__) || defined(__i386__)
     unsigned int lo, hi;
     __asm__ __volatile__ ("rdtsc" : "=a" (lo), "=d" (hi));
     return ((uint64_t) hi << 32) | lo;
+#elif defined(__aarch64__)
+    /// aarch64 (e.g. Apple Silicon) has no rdtsc; use the virtual count register.
+    uint64_t val;
+    __asm__ __volatile__ ("mrs %0, cntvct_el0" : "=r" (val));
+    return val;
+#else
+    return 0;
+#endif
   }
 }
 

--- a/Chapter12/common/thread_utils.h
+++ b/Chapter12/common/thread_utils.h
@@ -10,12 +10,19 @@
 namespace Common {
   /// Set affinity for current thread to be pinned to the provided core_id.
   inline auto setThreadCore(int core_id) noexcept {
+#if defined(__linux__)
     cpu_set_t cpuset;
 
     CPU_ZERO(&cpuset);
     CPU_SET(core_id, &cpuset);
 
     return (pthread_setaffinity_np(pthread_self(), sizeof(cpu_set_t), &cpuset) == 0);
+#else
+    /// Thread affinity pinning is a Linux-only API (cpu_set_t / pthread_setaffinity_np);
+    /// on other platforms (e.g. macOS) it is a no-op so the code stays portable for testing.
+    (void) core_id;
+    return true;
+#endif
   }
 
   /// Creates a thread instance, sets affinity on it, assigns it a name and

--- a/Chapter12/exchange/matcher/me_order_book.h
+++ b/Chapter12/exchange/matcher/me_order_book.h
@@ -154,7 +154,7 @@ namespace Exchange {
       orders_at_price_pool_.deallocate(orders_at_price);
     }
 
-    auto getNextPriority(Price price) noexcept {
+    auto getNextPriority(Price price) noexcept -> Priority {
       const auto orders_at_price = getOrdersAtPrice(price);
       if (!orders_at_price)
         return 1lu;

--- a/Chapter12/tests/README.md
+++ b/Chapter12/tests/README.md
@@ -1,0 +1,71 @@
+# MEOrderBook unit tests
+
+Unit tests for `Exchange::MEOrderBook` (the matching-engine limit order book).
+
+## What is covered
+
+`me_order_book_test.cpp` drives orders through a real `MatchingEngine`
+(single-threaded — it never calls `start()`, so everything runs on the test
+thread) and asserts on the client responses and market updates the book emits.
+
+| Test | Scenario |
+| --- | --- |
+| `test_add_resting_order` | A non-crossing order → `ACCEPTED` response + `ADD` market update |
+| `test_full_match` | Aggressor fully crosses a resting order → 2×`FILLED` + `TRADE`/`CANCEL`, no `ADD` |
+| `test_partial_match_leaves_rest` | Aggressor partially fills, remainder rests → `ADD` for the leftover |
+| `test_no_cross_when_prices_dont_meet` | Bid < ask → no trade, order just rests |
+| `test_fifo_price_time_priority` | Two orders at the same price → earliest one fills first |
+| `test_best_price_selection` | Multiple price levels → match happens at the best price |
+| `test_cancel_resting_order` | Cancel → `CANCELED` response + `CANCEL` market update |
+| `test_cancel_nonexistent_order_rejected` | Cancel of an unknown order → `CANCEL_REJECTED` |
+
+## Running
+
+From `Chapter12/`:
+
+```bash
+bash tests/run_tests.sh
+```
+
+Expected tail:
+
+```
+39/39 checks passed
+RESULT: PASSED
+```
+
+## Why the test builds under AddressSanitizer by default
+
+Each `MEOrderBook` embeds a `cid_oid_to_order_` array **by value**
+(`ME_MAX_NUM_CLIENTS * ME_MAX_ORDER_IDS` pointers ≈ 2 GB), and a
+`MatchingEngine` constructs 8 of them → ~16 GB of virtual reservations. macOS's
+default allocator misbehaves at that scale in a plain build (segfault), even
+though the order-book logic is correct.
+
+Two independent checks confirm it is a footprint issue, not a logic bug:
+
+1. Shrinking the capacity constants (`ME_MAX_ORDER_IDS`, `ME_MAX_NUM_CLIENTS`)
+   makes a plain `-O0` build pass 39/39.
+2. The AddressSanitizer build — which uses its own allocator **and** full
+   memory-safety checking — passes 39/39 at the real full-size config.
+
+So `run_tests.sh` builds with `-fsanitize=address`. On Linux (with overcommit)
+the plain build runs fine natively:
+
+```bash
+NO_ASAN=1 bash tests/run_tests.sh
+```
+
+## Cross-platform note
+
+The book's code targets x86/Linux. Small, platform-guarded shims were added so
+it also compiles/runs on arm64 macOS (the x86/Linux path is unchanged):
+
+- `common/perf_utils.h` — `rdtsc()` gained an aarch64 (`cntvct_el0`) branch.
+- `common/thread_utils.h` — Linux-only thread affinity (`cpu_set_t` /
+  `pthread_setaffinity_np`) is a no-op elsewhere.
+- `common/lf_queue.h` — `std::to_string(pthread_self())` uses a cast that works
+  where `pthread_t` is a pointer (macOS).
+- `exchange/matcher/me_order_book.h` — `getNextPriority()` now has an explicit
+  `-> Priority` return type (its `auto` deduction was ill-formed where
+  `Priority` is not `unsigned long`).

--- a/Chapter12/tests/me_order_book_test.cpp
+++ b/Chapter12/tests/me_order_book_test.cpp
@@ -1,0 +1,302 @@
+// Standalone unit tests for Exchange::MEOrderBook.
+//
+// MEOrderBook publishes its results (client responses + market updates) back
+// through its parent MatchingEngine into two lock-free queues. We construct a
+// real MatchingEngine (but never call start(), so everything runs on this
+// thread), drive orders through MatchingEngine::processClientRequest(), and
+// drain the output queues to assert on the observable behavior.
+//
+// Build/run: see tests/run_tests.sh (or the command at the bottom of this file).
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+#include <string>
+
+#include "matcher/matching_engine.h"
+
+using namespace Common;
+using namespace Exchange;
+
+namespace {
+  int g_checks = 0;
+  int g_failures = 0;
+
+  #define CHECK(cond, msg)                                                        \
+    do {                                                                          \
+      ++g_checks;                                                                 \
+      if (!(cond)) {                                                              \
+        ++g_failures;                                                            \
+        std::cerr << "  [FAIL] " << (msg) << "  (" << #cond << ") @ line "        \
+                  << __LINE__ << "\n";                                            \
+      }                                                                           \
+    } while (0)
+
+  /// Test harness that owns the queues + matching engine and exposes helpers to
+  /// submit requests and drain the resulting responses / market updates.
+  struct Harness {
+    ClientRequestLFQueue  requests{ME_MAX_CLIENT_UPDATES};
+    ClientResponseLFQueue responses{ME_MAX_CLIENT_UPDATES};
+    MEMarketUpdateLFQueue market_updates{ME_MAX_MARKET_UPDATES};
+    MatchingEngine engine{&requests, &responses, &market_updates};
+
+    /// Submit a NEW order request straight into the matching engine.
+    auto add(ClientId cid, OrderId oid, TickerId ticker, Side side, Price px, Qty qty) {
+      MEClientRequest req{ClientRequestType::NEW, cid, ticker, oid, side, px, qty};
+      engine.processClientRequest(&req);
+    }
+
+    /// Submit a CANCEL request straight into the matching engine.
+    auto cancel(ClientId cid, OrderId oid, TickerId ticker) {
+      MEClientRequest req{ClientRequestType::CANCEL, cid, ticker, oid,
+                          Side::INVALID, Price_INVALID, Qty_INVALID};
+      engine.processClientRequest(&req);
+    }
+
+    /// Drain and return all pending client responses.
+    auto drainResponses() -> std::vector<MEClientResponse> {
+      std::vector<MEClientResponse> out;
+      while (responses.size()) {
+        out.push_back(*responses.getNextToRead());
+        responses.updateReadIndex();
+      }
+      return out;
+    }
+
+    /// Drain and return all pending market updates.
+    auto drainMarketUpdates() -> std::vector<MEMarketUpdate> {
+      std::vector<MEMarketUpdate> out;
+      while (market_updates.size()) {
+        out.push_back(*market_updates.getNextToRead());
+        market_updates.updateReadIndex();
+      }
+      return out;
+    }
+  };
+
+  constexpr TickerId T = 1;
+
+  // -------------------------------------------------------------------------
+  void test_add_resting_order() {
+    std::cout << "test_add_resting_order\n";
+    Harness h;
+
+    h.add(/*cid*/1, /*oid*/100, T, Side::BUY, /*px*/100, /*qty*/10);
+
+    auto resp = h.drainResponses();
+    auto md   = h.drainMarketUpdates();
+
+    // A non-crossing order produces exactly one ACCEPTED response...
+    CHECK(resp.size() == 1, "one client response for a resting add");
+    CHECK(resp[0].type_ == ClientResponseType::ACCEPTED, "response is ACCEPTED");
+    CHECK(resp[0].client_id_ == 1 && resp[0].client_order_id_ == 100, "response echoes client/order id");
+    CHECK(resp[0].leaves_qty_ == 10, "full qty rests");
+
+    // ...and exactly one ADD market update at the resting price.
+    CHECK(md.size() == 1, "one market update for a resting add");
+    CHECK(md[0].type_ == MarketUpdateType::ADD, "market update is ADD");
+    CHECK(md[0].price_ == 100 && md[0].qty_ == 10 && md[0].side_ == Side::BUY, "ADD carries order attributes");
+  }
+
+  // -------------------------------------------------------------------------
+  void test_full_match() {
+    std::cout << "test_full_match\n";
+    Harness h;
+
+    h.add(1, 100, T, Side::BUY, 100, 10); // resting bid
+    h.drainResponses();
+    h.drainMarketUpdates();
+
+    h.add(2, 200, T, Side::SELL, 100, 10); // aggressive sell that fully crosses
+
+    auto resp = h.drainResponses();
+    auto md   = h.drainMarketUpdates();
+
+    // Expect: ACCEPTED(aggressor) + FILLED(aggressor) + FILLED(resting).
+    CHECK(resp.size() == 3, "three responses on a full match");
+    CHECK(resp[0].type_ == ClientResponseType::ACCEPTED, "first response ACCEPTED");
+    CHECK(resp[1].type_ == ClientResponseType::FILLED, "aggressor FILLED");
+    CHECK(resp[1].client_id_ == 2 && resp[1].leaves_qty_ == 0, "aggressor fully filled, nothing leaves");
+    CHECK(resp[2].type_ == ClientResponseType::FILLED, "resting FILLED");
+    CHECK(resp[2].client_id_ == 1 && resp[2].leaves_qty_ == 0, "resting fully filled");
+    CHECK(resp[1].exec_qty_ == 10 && resp[2].exec_qty_ == 10, "both fills are for 10");
+
+    // Market updates: TRADE, then CANCEL (resting order fully consumed).
+    // No ADD, since the aggressor left nothing to rest.
+    bool saw_trade = false, saw_cancel = false, saw_add = false;
+    for (const auto &u : md) {
+      saw_trade  |= (u.type_ == MarketUpdateType::TRADE);
+      saw_cancel |= (u.type_ == MarketUpdateType::CANCEL);
+      saw_add    |= (u.type_ == MarketUpdateType::ADD);
+    }
+    CHECK(saw_trade, "a TRADE was published");
+    CHECK(saw_cancel, "consumed resting order published CANCEL");
+    CHECK(!saw_add, "nothing rested, so no ADD");
+  }
+
+  // -------------------------------------------------------------------------
+  void test_partial_match_leaves_rest() {
+    std::cout << "test_partial_match_leaves_rest\n";
+    Harness h;
+
+    h.add(1, 100, T, Side::BUY, 100, 6);  // resting bid, qty 6
+    h.drainResponses();
+    h.drainMarketUpdates();
+
+    h.add(2, 200, T, Side::SELL, 100, 10); // sell 10 -> 6 filled, 4 rests as ask
+
+    auto resp = h.drainResponses();
+    auto md   = h.drainMarketUpdates();
+
+    CHECK(resp.size() == 3, "ACCEPTED + 2 FILLED on partial cross");
+    CHECK(resp[1].exec_qty_ == 6, "6 executed");
+    CHECK(resp[1].leaves_qty_ == 4, "4 leaves on the aggressor");
+
+    // The bid was fully consumed (CANCEL) and the remaining 4 rest (ADD).
+    const MEMarketUpdate *add = nullptr;
+    bool saw_trade = false, saw_cancel = false;
+    for (const auto &u : md) {
+      if (u.type_ == MarketUpdateType::ADD) add = &u;
+      saw_trade  |= (u.type_ == MarketUpdateType::TRADE);
+      saw_cancel |= (u.type_ == MarketUpdateType::CANCEL);
+    }
+    CHECK(saw_trade, "TRADE published");
+    CHECK(saw_cancel, "fully-consumed bid published CANCEL");
+    CHECK(add != nullptr, "remaining qty rested via ADD");
+    if (add) {
+      CHECK(add->side_ == Side::SELL && add->qty_ == 4 && add->price_ == 100, "resting remainder is SELL 4 @ 100");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  void test_no_cross_when_prices_dont_meet() {
+    std::cout << "test_no_cross_when_prices_dont_meet\n";
+    Harness h;
+
+    h.add(1, 100, T, Side::BUY, 100, 10);  // bid @ 100
+    h.drainResponses();
+    h.drainMarketUpdates();
+
+    h.add(2, 200, T, Side::SELL, 101, 10); // ask @ 101 does not cross bid @ 100
+
+    auto resp = h.drainResponses();
+    auto md   = h.drainMarketUpdates();
+
+    CHECK(resp.size() == 1 && resp[0].type_ == ClientResponseType::ACCEPTED, "only ACCEPTED, no fill");
+    CHECK(md.size() == 1 && md[0].type_ == MarketUpdateType::ADD, "only ADD, no TRADE");
+  }
+
+  // -------------------------------------------------------------------------
+  void test_fifo_price_time_priority() {
+    std::cout << "test_fifo_price_time_priority\n";
+    Harness h;
+
+    // Two bids at the same price; first one in gets first fill (FIFO).
+    h.add(1, 100, T, Side::BUY, 100, 10);
+    h.add(2, 200, T, Side::BUY, 100, 10);
+    h.drainResponses();
+    h.drainMarketUpdates();
+
+    // Aggressive sell of 10 should hit client 1 (earliest) only.
+    h.add(3, 300, T, Side::SELL, 100, 10);
+    auto resp = h.drainResponses();
+
+    // Find the FILLED response that belongs to a resting order (not the aggressor cid 3).
+    const MEClientResponse *resting_fill = nullptr;
+    for (const auto &r : resp) {
+      if (r.type_ == ClientResponseType::FILLED && r.client_id_ != 3) resting_fill = &r;
+    }
+    CHECK(resting_fill != nullptr, "a resting order was filled");
+    if (resting_fill) {
+      CHECK(resting_fill->client_id_ == 1, "earliest order (client 1) filled first, not client 2");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  void test_best_price_selection() {
+    std::cout << "test_best_price_selection\n";
+    Harness h;
+
+    // Bids at 99, 100, 98 -> best (highest) bid is 100.
+    h.add(1, 1, T, Side::BUY, 99,  10);
+    h.add(1, 2, T, Side::BUY, 100, 10);
+    h.add(1, 3, T, Side::BUY, 98,  10);
+    h.drainResponses();
+    h.drainMarketUpdates();
+
+    // Sell 5 @ 100 must match against the best bid (100), i.e. order id 2.
+    h.add(2, 200, T, Side::SELL, 100, 5);
+    auto resp = h.drainResponses();
+
+    const MEClientResponse *resting_fill = nullptr;
+    for (const auto &r : resp) {
+      if (r.type_ == ClientResponseType::FILLED && r.client_id_ == 1) resting_fill = &r;
+    }
+    CHECK(resting_fill != nullptr, "best bid was filled");
+    if (resting_fill) {
+      CHECK(resting_fill->price_ == 100, "match happened at best bid price 100");
+      CHECK(resting_fill->client_order_id_ == 2, "best-priced order (oid 2) matched");
+      CHECK(resting_fill->leaves_qty_ == 5, "best bid partially filled, 5 remain");
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  void test_cancel_resting_order() {
+    std::cout << "test_cancel_resting_order\n";
+    Harness h;
+
+    h.add(1, 100, T, Side::BUY, 100, 10);
+    h.drainResponses();
+    h.drainMarketUpdates();
+
+    h.cancel(1, 100, T);
+    auto resp = h.drainResponses();
+    auto md   = h.drainMarketUpdates();
+
+    CHECK(resp.size() == 1 && resp[0].type_ == ClientResponseType::CANCELED, "CANCELED response");
+    CHECK(resp[0].client_order_id_ == 100, "canceled the right order");
+    CHECK(md.size() == 1 && md[0].type_ == MarketUpdateType::CANCEL, "CANCEL market update");
+
+    // A subsequent crossing sell should now find nothing to trade against.
+    h.add(2, 200, T, Side::SELL, 100, 10);
+    auto resp2 = h.drainResponses();
+    bool any_fill = false;
+    for (const auto &r : resp2) any_fill |= (r.type_ == ClientResponseType::FILLED);
+    CHECK(!any_fill, "no fills after the resting bid was canceled");
+  }
+
+  // -------------------------------------------------------------------------
+  void test_cancel_nonexistent_order_rejected() {
+    std::cout << "test_cancel_nonexistent_order_rejected\n";
+    Harness h;
+
+    h.cancel(1, 999, T); // never added
+    auto resp = h.drainResponses();
+
+    CHECK(resp.size() == 1, "one response for a bad cancel");
+    CHECK(resp[0].type_ == ClientResponseType::CANCEL_REJECTED, "CANCEL_REJECTED for unknown order");
+    CHECK(resp[0].client_order_id_ == 999, "rejection echoes the requested order id");
+  }
+} // namespace
+
+int main() {
+  std::cout << std::unitbuf; // flush after every write so a crash points at the right test.
+  std::cout << "=== MEOrderBook tests ===\n";
+
+  test_add_resting_order();
+  test_full_match();
+  test_partial_match_leaves_rest();
+  test_no_cross_when_prices_dont_meet();
+  test_fifo_price_time_priority();
+  test_best_price_selection();
+  test_cancel_resting_order();
+  test_cancel_nonexistent_order_rejected();
+
+  std::cout << "\n" << (g_checks - g_failures) << "/" << g_checks << " checks passed\n";
+  if (g_failures) {
+    std::cout << "RESULT: FAILED (" << g_failures << " failing checks)\n";
+    return 1;
+  }
+  std::cout << "RESULT: PASSED\n";
+  return 0;
+}

--- a/Chapter12/tests/run_tests.sh
+++ b/Chapter12/tests/run_tests.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Build and run the MEOrderBook unit tests.
+#
+# The tests drive orders through a real MatchingEngine (single-threaded, no
+# start()) and assert on the client responses + market updates it emits.
+#
+# NOTE ON macOS: each MEOrderBook embeds a ~2GB cid_oid_to_order_ array by
+# value (ME_MAX_NUM_CLIENTS * ME_MAX_ORDER_IDS pointers), and a MatchingEngine
+# builds 8 of them -> ~16GB of virtual reservations. macOS's default allocator
+# is unhappy at that scale in a plain build, so we build under AddressSanitizer
+# by default, which uses its own allocator and also validates memory safety.
+# On Linux you can drop -fsanitize=address and it will run fine natively.
+
+set -e
+cd "$(dirname "$0")/.."   # -> Chapter12
+
+OUT="${TMPDIR:-/tmp}/me_order_book_test"
+
+# -Wno-* silence pre-existing warnings in the book's own code (sprintf usage,
+# %ld vs long long) so the test output stays readable.
+FLAGS="-std=c++2a -g -O1 -Wall -Wno-deprecated-declarations -Wno-format -I. -Iexchange"
+if [ "${NO_ASAN:-0}" != "1" ]; then
+  FLAGS="$FLAGS -fsanitize=address"
+fi
+
+echo "Building ($FLAGS)..."
+g++ $FLAGS \
+  tests/me_order_book_test.cpp \
+  exchange/matcher/matching_engine.cpp \
+  exchange/matcher/me_order_book.cpp \
+  exchange/matcher/me_order.cpp \
+  -o "$OUT" -lpthread
+
+echo "Running..."
+ASAN_OPTIONS=detect_leaks=0 "$OUT"


### PR DESCRIPTION
Add a standalone unit-test suite for Exchange::MEOrderBook that drives orders through a real MatchingEngine (single-threaded) and asserts on the emitted client responses and market updates. Covers resting adds, full and partial matches, non-crossing orders, FIFO price-time priority, best-price selection, cancels, and cancel-rejections (39 checks).

Also add small, platform-guarded shims so the x86/Linux code compiles and runs on arm64 macOS (the x86/Linux path is byte-for-byte unchanged):
- perf_utils.h: aarch64 (cntvct_el0) branch for rdtsc()
- thread_utils.h: no-op thread affinity off Linux
- lf_queue.h: cast pthread_self() for platforms where pthread_t is a pointer
- me_order_book.h: explicit -> Priority return type on getNextPriority() (fixes an ill-formed auto deduction where Priority != unsigned long)

tests/run_tests.sh builds under AddressSanitizer by default (the full-size config reserves ~16GB of virtual memory which the plain macOS allocator mishandles; ASAN's allocator handles it and adds memory-safety checks). tests/README.md documents usage and the rationale.